### PR TITLE
fix #371

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## AREPL [![Build Status](https://github.com/Almenon/AREPL-vscode/workflows/.github/workflows/main.yml/badge.svg?branch=master)](https://github.com/Almenon/AREPL-vscode/actions?query=workflow%3A.github%2Fworkflows%2Fmain.yml) [![Downloads](https://vsmarketplacebadge.apphb.com/installs/almenon.arepl.svg)](https://marketplace.visualstudio.com/items?itemName=almenon.arepl) [![Downloads](https://vsmarketplacebadge.apphb.com/rating-star/almenon.arepl.svg)](https://marketplace.visualstudio.com/items?itemName=almenon.arepl) [![Gitter chat](https://badges.gitter.im/arepl/gitter.png)](https://gitter.im/arepl/lobby)
+## AREPL [![Build Status](https://github.com/Almenon/AREPL-vscode/workflows/.github/workflows/main.yml/badge.svg?branch=master)](https://github.com/Almenon/AREPL-vscode/actions?query=workflow%3A.github%2Fworkflows%2Fmain.yml) [![Gitter chat](https://badges.gitter.im/arepl/gitter.png)](https://gitter.im/arepl/lobby)
 
 AREPL automatically evaluates python code in real-time as you type.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## v2.0.5 (3/5/2023) 🐛🚀
+🐛 [Fixed inconsistent variable display in certain cases](https://github.com/Almenon/AREPL-vscode/issues/3716)
+
+🚀 Basic types no longer appear as variables. This was done by updating the `arepl.defaultfiltertypes` setting.
+
+
 ## v2.0.4 (10/23/2022) 🐛🚀
 🐛 [Fixed 'typing is not a package' error](https://github.com/Almenon/AREPL-vscode/issues/416)
 
@@ -24,6 +30,7 @@
 ## [v1.0.26](https://github.com/Almenon/AREPL-vscode/milestone/44?closed=1) (11/22/2020) 🐛🐛
 
 🐛 Fixed error with AREPL.skipLandingPage setting
+
 🐛 Fixed error when a exception was raised while using dump
 
 ## [v1.0.25](https://github.com/Almenon/AREPL-vscode/milestone/43?closed=1) (11/07/2020) 🔧🚀🐛
@@ -242,14 +249,20 @@ jsonPickle version upgrade w/ slightly better numpy and pandas support
 ## [v1.0.0](https://github.com/Almenon/AREPL-vscode/milestone/16?closed=1) 🐛
 
 Fixed: 🐛 
+
 🐛 #86 unittest causes arepl to fail silently bug
+
 🐛 #101 styling becomes wierd when in certain scenarios bug 
+
 🐛 #102  internal error does not show bug
+
 🐛 #94  arepl frequently has problems rendering when there is a lot of prints bug
 
-Updated:
+Updated: 🚀
+
 #56  use new webview enhancement
-#52 Update vscode-extension-telemetry to the latest version 🚀  greenkeeper
+
+#52 Update vscode-extension-telemetry to the latest version
 
 ## [v1.5](https://github.com/Almenon/AREPL-vscode/milestone/15?closed=1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arepl",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arepl",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "SEE LICENSE IN <filename>",
       "dependencies": {
         "arepl-backend": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.4",
       "license": "SEE LICENSE IN <filename>",
       "dependencies": {
-        "arepl-backend": "^2.0.2",
+        "arepl-backend": "^2.1.0",
         "opn": "^5.3.0",
         "path": "^0.12.7",
         "vscode-extension-telemetry": "0.1.2"
@@ -149,11 +149,11 @@
       }
     },
     "node_modules/arepl-backend": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-2.0.2.tgz",
-      "integrity": "sha512-9pGOIkCnTL9SKNa8UumLN3QJASbaUZRtjpUbgPuqgojv6JUsWWBGO0OKehIr8+A09T0SUK52rsNptxMWXDjHFg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-2.1.0.tgz",
+      "integrity": "sha512-AY/xKOVyW7gRJGhKL2PDAVHcSy91hUTeyazRlMzeIIBfjdddSUkiOFOEW6BEZLXZ7yn6CsDxtEqKHDIx/PF+/g==",
       "dependencies": {
-        "python-shell": "^3.0.1"
+        "python-shell": "^5.0.0"
       }
     },
     "node_modules/arg": {
@@ -1029,9 +1029,9 @@
       }
     },
     "node_modules/python-shell": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-3.0.1.tgz",
-      "integrity": "sha512-TWeotuxe1auhXa5bGRScxnc2J+0r41NBntSa6RYZtMBLtAEsvCboKrEbW6DvASosWQepVkhZZlT3B5Ei766G+Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==",
       "engines": {
         "node": ">=0.10"
       }
@@ -1512,11 +1512,11 @@
       }
     },
     "arepl-backend": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-2.0.2.tgz",
-      "integrity": "sha512-9pGOIkCnTL9SKNa8UumLN3QJASbaUZRtjpUbgPuqgojv6JUsWWBGO0OKehIr8+A09T0SUK52rsNptxMWXDjHFg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-2.1.0.tgz",
+      "integrity": "sha512-AY/xKOVyW7gRJGhKL2PDAVHcSy91hUTeyazRlMzeIIBfjdddSUkiOFOEW6BEZLXZ7yn6CsDxtEqKHDIx/PF+/g==",
       "requires": {
-        "python-shell": "^3.0.1"
+        "python-shell": "^5.0.0"
       }
     },
     "arg": {
@@ -2175,9 +2175,9 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "python-shell": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-3.0.1.tgz",
-      "integrity": "sha512-TWeotuxe1auhXa5bGRScxnc2J+0r41NBntSa6RYZtMBLtAEsvCboKrEbW6DvASosWQepVkhZZlT3B5Ei766G+Q=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "vscode-uri": "^2.1.2"
   },
   "dependencies": {
-    "arepl-backend": "^2.0.2",
+    "arepl-backend": "^2.1.0",
     "opn": "^5.3.0",
     "path": "^0.12.7",
     "vscode-extension-telemetry": "0.1.2"

--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
             "<class 'typing._SpecialForm'>",
             "<class 'typing._SpecialGenericAlias'>",
             "<class 'module'>",
-            "<class 'function'>"
+            "<class 'function'>",
+            "<class 'builtin_function_or_method'>"
           ],
           "description": "Any variables with these types are not shown in arepl variable view. You can use the arepl_filter_type variable in arepl to play around with this setting in real-time"
         },

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
         "AREPL.defaultFilterTypes": {
           "type": "array",
           "default": [
+            "<class 'typing._SpecialForm'>",
             "<class 'typing._SpecialGenericAlias'>",
             "<class 'module'>",
             "<class 'function'>"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arepl",
   "displayName": "AREPL for python",
   "description": "real-time python scratchpad",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "publisher": "almenon",
   "engines": {
     "vscode": "^1.36.0"

--- a/src/pythonPanelPreview.ts
+++ b/src/pythonPanelPreview.ts
@@ -27,10 +27,10 @@ export default class PythonPanelPreview {
     <p style="font-size:14px">⚠ <b style="color:red">WARNING:</b> code is evaluated WHILE YOU TYPE - don't try deleting files/folders! ⚠</p>
     <p>Evaluation while you type can be turned off or adjusted in the settings</p>
     <br>
-    <h3>AREPL v2.0.4 🐛 - Haru</h3>
+    <h3>AREPL v2.0.5 🐛 - Mushi-mezuru Himegimi</h3>
     <ul>
-    <li>🐛 <a href="https://github.com/Almenon/AREPL-vscode/issues/416">Fixed 'typing is not a package' error</a></li>
-    <li>🚀 <a href="https://github.com/Almenon/AREPL-vscode/issues/257">AREPL preview window now respects editor font size and weight</a></li>
+    <li>🐛 <a href="https://github.com/Almenon/AREPL-vscode/issues/371">Fixed inconsistent variable display in certain cases</a></li>
+    <li>🚀 Basic types no longer appear as variables</li>
     <li>Help me make arepl better by filling out this short survey: <a href="https://forms.gle/m7xirfRnSRoPAe9e9">https://forms.gle/m7xirfRnSRoPAe9e9</a></li>
     </ul>
     <br>


### PR DESCRIPTION
This upgrades arepl-backend, which in turn has a upgrade of jsonpickle. This fixes #371 and may fix certain python 3.11 failures. It also adds more attributes to file objects. 