### PR TITLE
Add macOS tests to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout


### PR DESCRIPTION
Things added/changed:

- Add macOS tests to the CI.
  - Closes #452.
  - The more tests on more operating systems, the better. 🙂
