### PR TITLE
Remove saved

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,6 +13,14 @@ tsconfig.json
 personal/**
 .travis.yml
 dependencygraph.svg
+.hypothesis
+.env
+.vscode-test.js
+areplDemoGif2.gif
+copy_backend.bat
+notes.txt
+*.code-workspace
+tslint.json
 #pycharm dir
 .idea/**
 # coverage output

--- a/README.md
+++ b/README.md
@@ -145,38 +145,6 @@ I have [overridden the display](https://github.com/Almenon/AREPL-backend/blob/ma
 If you want a type to be displayed in a particular manner just [file an issue](https://github.com/Almenon/AREPL-vscode/issues)
 
 
-### #$save
-
-*This is buggy and I would suggest using the [arepl_store variable](https://github.com/Almenon/AREPL-vscode/wiki/Caching-data-between-runs) instead*
-
-If you want to avoid a section of code being executed in real-time (due to it being slow or calling external resources) you can use \#\$save.  For example:
-
-```python
-def largest_prime_factor(n):
-    i = 2
-    while i * i <= n:
-        if n % i:
-            i += 1
-        else:
-            n //= i
-    return n
-
-# this takes a looonnggg time to execute
-result = largest_prime_factor(8008514751439999)
-
-#$save
-print("but now that i saved i am back to real-time execution")
-```
-
-```python
-import random
-x = random.random()
-#$save
-print(x) # this number will not change when editing below the #$save line
-```
-
-Please note that \#\$save [does not work](https://github.com/Almenon/AREPL-vscode/issues/53) with certain types, like generators.  If #$save fails in pickling the code state [file an issue](https://github.com/Almenon/AREPL-vscode/issues) so I can look into it.
-
 ### More Stuff
 
 Check out the [wiki](https://github.com/Almenon/AREPL-vscode/wiki)!

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 🐛 As a consequence of above, AREPL will no longer crash when there is a infinite loop
 🐛 As a consequence of above, pandas now works better
 🐛 As a consequence of above, boto3 now works better
+🔧 `#$save` feature has been removed
+🔧 Removed `keepPreviousVars` setting
+🔧 `arepl_store` variable has been removed.
 
 ## v2.0.5 (3/5/2023) 🐛🚀
 🐛 [Fixed inconsistent variable display in certain cases](https://github.com/Almenon/AREPL-vscode/issues/3716)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN <filename>",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
-        "arepl-backend": "^3.0.3"
+        "arepl-backend": "^3.0.4"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/arepl-backend": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.3.tgz",
-      "integrity": "sha512-ruzBMW4/szcfkxlpuroWiJsnI1Rc9odFZOjh60tvLbrFC7dFhchWiB9SVRDve5XMIW6spkp2a/oN7t/SBzCCJw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.4.tgz",
+      "integrity": "sha512-HSVWEpttvhbpLWAZ8pxJdYRs29iviaS8qncQUMLFRDnQtQrwxZqeMzOb9sg2OqvAc2vy8yK1PtIvTshWvICcDw==",
       "dependencies": {
         "python-shell": "^5.0.0"
       }
@@ -2934,9 +2934,9 @@
       }
     },
     "arepl-backend": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.3.tgz",
-      "integrity": "sha512-ruzBMW4/szcfkxlpuroWiJsnI1Rc9odFZOjh60tvLbrFC7dFhchWiB9SVRDve5XMIW6spkp2a/oN7t/SBzCCJw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.4.tgz",
+      "integrity": "sha512-HSVWEpttvhbpLWAZ8pxJdYRs29iviaS8qncQUMLFRDnQtQrwxZqeMzOb9sg2OqvAc2vy8yK1PtIvTshWvICcDw==",
       "requires": {
         "python-shell": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN <filename>",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
-        "arepl-backend": "^3.0.4"
+        "arepl-backend": "^3.0.5"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/arepl-backend": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.4.tgz",
-      "integrity": "sha512-HSVWEpttvhbpLWAZ8pxJdYRs29iviaS8qncQUMLFRDnQtQrwxZqeMzOb9sg2OqvAc2vy8yK1PtIvTshWvICcDw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.5.tgz",
+      "integrity": "sha512-OE/EEmq3uplEDGzAl5V+JTCNU2bIfBGXUTb0ExYO4jkPPB7ZdSRlba0IYGDv0VSyBiVRZWE9gXtZEdet2Ynudw==",
       "dependencies": {
         "python-shell": "^5.0.0"
       }
@@ -2934,9 +2934,9 @@
       }
     },
     "arepl-backend": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.4.tgz",
-      "integrity": "sha512-HSVWEpttvhbpLWAZ8pxJdYRs29iviaS8qncQUMLFRDnQtQrwxZqeMzOb9sg2OqvAc2vy8yK1PtIvTshWvICcDw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/arepl-backend/-/arepl-backend-3.0.5.tgz",
+      "integrity": "sha512-OE/EEmq3uplEDGzAl5V+JTCNU2bIfBGXUTb0ExYO4jkPPB7ZdSRlba0IYGDv0VSyBiVRZWE9gXtZEdet2Ynudw==",
       "requires": {
         "python-shell": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.7",
-    "arepl-backend": "^3.0.4"
+    "arepl-backend": "^3.0.5"
   },
   "bugs": {
     "url": "https://github.com/almenon/arepl-vscode-wordcount/issues",

--- a/package.json
+++ b/package.json
@@ -193,11 +193,6 @@
           "type": "boolean",
           "default": false,
           "description": "Whether to automatically load django models. This setting doesn't actually do anything yet. See https://github.com/Almenon/AREPL-vscode/issues/279"
-        },
-        "AREPL.keepPreviousVars": {
-          "type": "boolean",
-          "default": false,
-          "description": "If set to true AREPL will add onto the local state each run instead of clearing it and starting fresh."
         }
       }
     },
@@ -292,7 +287,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.7",
-    "arepl-backend": "^3.0.3"
+    "arepl-backend": "^3.0.4"
   },
   "bugs": {
     "url": "https://github.com/almenon/arepl-vscode-wordcount/issues",

--- a/src/PreviewManager.ts
+++ b/src/PreviewManager.ts
@@ -142,6 +142,7 @@ export default class PreviewManager {
         const data: ExecArgs = {
             evalCode: codeLines,
             filePath,
+            usePreviousVariables: true,
             show_global_vars: settingsCached.get<boolean>('showGlobalVars'),
             default_filter_vars: settingsCached.get<string[]>('defaultFilterVars'),
             default_filter_types: settingsCached.get<string[]>('defaultFilterTypes')

--- a/src/PreviewManager.ts
+++ b/src/PreviewManager.ts
@@ -142,8 +142,6 @@ export default class PreviewManager {
         const data: ExecArgs = {
             evalCode: codeLines,
             filePath,
-            savedCode: '',
-            usePreviousVariables: true,
             show_global_vars: settingsCached.get<boolean>('showGlobalVars'),
             default_filter_vars: settingsCached.get<string[]>('defaultFilterVars'),
             default_filter_types: settingsCached.get<string[]>('defaultFilterTypes')

--- a/src/pythonPanelPreview.ts
+++ b/src/pythonPanelPreview.ts
@@ -40,15 +40,13 @@ export default class PythonPanelPreview {
     <h3>Examples</h3>
     
 <h4>Simple List</h4>
-<code style="white-space:pre-wrap">
-x = [1,2,3]
+<code style="white-space:pre-wrap">x = [1,2,3]
 y = [num*2 for num in x]
 print(y)
 </code>
 
 <h4>Dumping</h4>
-<code style="white-space:pre-wrap">
-from arepl_dump import dump 
+<code style="white-space:pre-wrap">from arepl_dump import dump 
 
 def milesToKilometers(miles):
     kilometers = miles*1.60934
@@ -69,8 +67,7 @@ a=2
 </code>
 
 <h4>Turtle</h4>
-<code style="white-space:pre-wrap">
-import turtle
+<code style="white-space:pre-wrap">import turtle
 
 # window in right hand side of screen
 turtle.setup(500,500,-1,0)
@@ -83,8 +80,7 @@ turtle.left(90)
 </code>
 
 <h4>Web call</h4>
-<code style="white-space:pre-wrap">
-import requests
+<code style="white-space:pre-wrap">import requests
 import datetime as dt
 
 # We don't want to spam an API with calls every time we stop typing

--- a/src/pythonPanelPreview.ts
+++ b/src/pythonPanelPreview.ts
@@ -31,6 +31,9 @@ export default class PythonPanelPreview {
     <ul>
     <li>🦋 <a href="https://github.com/Almenon/AREPL-vscode/issues/439">AREPL now restarts the python backend each run. This eliminates many bugs, although you may see more CPU utilization.</a></li>
     <li>🐛 AREPL will no longer crash when there is a infinite loop</li>
+    <li>🔧 #$save feature has been removed</li>
+    <li>🔧 Removed keepPreviousVars setting</li>
+    <li>🔧 arepl_store variable has been removed. If you still use this please <a href="https://github.com/Almenon/AREPL-vscode/issues">file an issue</a> and I might be able to add it back in.</li>
     </ul>
     <br>
     
@@ -84,10 +87,11 @@ turtle.left(90)
 import requests
 import datetime as dt
 
+# We don't want to spam an API with calls every time we stop typing
+# so we use #$end to deactivate real-time mode for everything afterwords
+# then we can run blocks of code as desired with command-enter or control-enter
+#$end
 r = requests.get("https://api.github.com")
-
-#$save
-# #$save saves state so request is not re-executed when modifying below
 
 now = dt.datetime.now()
 if r.status_code == 200:

--- a/src/toAREPLLogic.ts
+++ b/src/toAREPLLogic.ts
@@ -41,7 +41,6 @@ export class ToAREPLLogic{
                 return
             }
         });
-        const endSection = codeLines.slice(endLineNum).join(eol)
         codeLines = codeLines.slice(startLineNum, endLineNum)
     
         const unsafeKeywords = settingsCached.get<string[]>('unsafeKeywords')
@@ -59,14 +58,12 @@ export class ToAREPLLogic{
             default_filter_types: settingsCached.get<string[]>('defaultFilterTypes')
         }
 
-        // user should be able to rerun code without changing anything
-        // only scenario where we dont re-run is if just end section is changed
-        if(endSection != this.lastEndSection && data.evalCode == this.lastCodeSection){
+        if(data.evalCode == this.lastCodeSection){
+            // nothing changed, no point in rerunning
             return false
         }
 
         this.lastCodeSection = data.evalCode
-        this.lastEndSection = endSection
         
         this.PythonExecutor.execCode(data)
 

--- a/src/toAREPLLogic.ts
+++ b/src/toAREPLLogic.ts
@@ -7,7 +7,6 @@ import {settings} from "./settings"
  */
 export class ToAREPLLogic{
 
-    lastSavedSection = ""
     lastCodeSection = ""
     lastEndSection = ""
 
@@ -33,16 +32,11 @@ export class ToAREPLLogic{
 
         let codeLines = text.split(eol)
     
-        let savedLines: string[] = []
         let startLineNum = 0
         let endLineNum = codeLines.length
 
         codeLines.forEach((line, i) => {
-            if(line.trimRight().endsWith("#$save")){
-                savedLines = codeLines.slice(0, i + 1)
-                startLineNum = i+1
-            }
-            if(line.trimRight().endsWith("#$end")){
+            if(line.trimEnd().endsWith("#$end")){
                 endLineNum = i+1
                 return
             }
@@ -60,8 +54,6 @@ export class ToAREPLLogic{
         const data: ExecArgs = {
             evalCode: codeLines.join(eol),
             filePath,
-            savedCode: savedLines.join(eol),
-            usePreviousVariables: settingsCached.get<boolean>('keepPreviousVars'),
             show_global_vars: showGlobalVars,
             default_filter_vars: settingsCached.get<string[]>('defaultFilterVars'),
             default_filter_types: settingsCached.get<string[]>('defaultFilterTypes')
@@ -69,12 +61,11 @@ export class ToAREPLLogic{
 
         // user should be able to rerun code without changing anything
         // only scenario where we dont re-run is if just end section is changed
-        if(endSection != this.lastEndSection && data.savedCode == this.lastSavedSection && data.evalCode == this.lastCodeSection){
+        if(endSection != this.lastEndSection && data.evalCode == this.lastCodeSection){
             return false
         }
 
         this.lastCodeSection = data.evalCode
-        this.lastSavedSection = data.savedCode
         this.lastEndSection = endSection
         
         this.PythonExecutor.execCode(data)


### PR DESCRIPTION
* Updated .vscode ignore to remove unneeded files from final extension bundle
* Removed #$save feature, not compatible with refactor
* Removed `keepPreviousVars` setting, not compatible with refactor
* Changed web call example to use `#$end` functionality
* Removed `arepl_store` variable, not compatible with refactor. I'm open to adding this functionality back in if someone wants.
* Fixed formatting in AREPL start screen